### PR TITLE
Update the way we identify suffixes to be more precise

### DIFF
--- a/src/loading_bar_middleware.js
+++ b/src/loading_bar_middleware.js
@@ -14,14 +14,14 @@ export default function loadingBarMiddleware(config = {}) {
 
     const [PENDING, FULFILLED, REJECTED] = promiseTypeSuffixes
 
-    const isPending = `_${PENDING}`
-    const isFulfilled = `_${FULFILLED}`
-    const isRejected = `_${REJECTED}`
+    const isPending = new RegExp(`${PENDING}$`, 'g')
+    const isFulfilled = new RegExp(`${FULFILLED}$`, 'g')
+    const isRejected = new RegExp(`${REJECTED}$`, 'g')
 
-    if (action.type.indexOf(isPending) !== -1) {
+    if (!!action.type.match(isPending)) {
       dispatch(showLoading())
-    } else if (action.type.indexOf(isFulfilled) !== -1 ||
-               action.type.indexOf(isRejected) !== -1) {
+    } else if (!!action.type.match(isFulfilled) ||
+               !!action.type.match(isRejected)) {
       dispatch(hideLoading())
     }
   }


### PR DESCRIPTION
When defining my prefixes like this promiseTypeSuffixes: `['LOAD', 'SUCCESS', 'FAIL']`, `react-redux-loading-bar` happened to show the LoadingBar when actions like `FOO_LOADED` were dispatched.

This comportement is not intended, and this case is just an example of the many cases where this could happen.

Now, using regular expressions, we check if suffixes are really at the end of the actions' types.
