### PR TITLE
Update the way we identify suffixes to be more precise

### DIFF
--- a/build/loading_bar_middleware.js
+++ b/build/loading_bar_middleware.js
@@ -34,13 +34,13 @@ function loadingBarMiddleware() {
         var REJECTED = _promiseTypeSuffixes[2];
 
 
-        var isPending = '_' + PENDING;
-        var isFulfilled = '_' + FULFILLED;
-        var isRejected = '_' + REJECTED;
+        var isPending = new RegExp(PENDING + '$', 'g');
+        var isFulfilled = new RegExp(FULFILLED + '$', 'g');
+        var isRejected = new RegExp(REJECTED + '$', 'g');
 
-        if (action.type.indexOf(isPending) !== -1) {
+        if (!!action.type.match(isPending)) {
           dispatch((0, _loading_bar_ducks.showLoading)());
-        } else if (action.type.indexOf(isFulfilled) !== -1 || action.type.indexOf(isRejected) !== -1) {
+        } else if (!!action.type.match(isFulfilled) || !!action.type.match(isRejected)) {
           dispatch((0, _loading_bar_ducks.hideLoading)());
         }
       };


### PR DESCRIPTION
When defining my suffixes like this promiseTypeSuffixes: ['LOAD', 'SUCCESS', 'FAIL'], react-redux-loading-bar happened to show the LoadingBar when actions like FOO_LOADED were dispatched.

This comportement is not intended, and this case is just an example of the many cases where this could happen.

Now, using regular expressions, we check if suffixes are really at the end of the actions' types.
