### PR TITLE
Respect redux middleware doc

### DIFF
--- a/build/loading_bar_middleware.js
+++ b/build/loading_bar_middleware.js
@@ -34,13 +34,13 @@ function loadingBarMiddleware() {
         var REJECTED = _promiseTypeSuffixes[2];
 
 
-        var isPending = '_' + PENDING;
-        var isFulfilled = '_' + FULFILLED;
-        var isRejected = '_' + REJECTED;
+        var isPending = new RegExp(PENDING + '$', 'g');
+        var isFulfilled = new RegExp(FULFILLED + '$', 'g');
+        var isRejected = new RegExp(REJECTED + '$', 'g');
 
-        if (action.type.indexOf(isPending) !== -1) {
+        if (!!action.type.match(isPending)) {
           dispatch((0, _loading_bar_ducks.showLoading)());
-        } else if (action.type.indexOf(isFulfilled) !== -1 || action.type.indexOf(isRejected) !== -1) {
+        } else if (!!action.type.match(isFulfilled) || !!action.type.match(isRejected)) {
           dispatch((0, _loading_bar_ducks.hideLoading)());
         }
       };

--- a/build/loading_bar_middleware.js
+++ b/build/loading_bar_middleware.js
@@ -21,10 +21,8 @@ function loadingBarMiddleware() {
     var dispatch = _ref.dispatch;
     return function (next) {
       return function (action) {
-        next(action);
-
         if (action.type === undefined) {
-          return;
+          return false;
         }
 
         var _promiseTypeSuffixes = _slicedToArray(promiseTypeSuffixes, 3);
@@ -43,6 +41,8 @@ function loadingBarMiddleware() {
         } else if (!!action.type.match(isFulfilled) || !!action.type.match(isRejected)) {
           dispatch((0, _loading_bar_ducks.hideLoading)());
         }
+
+        return next(action);
       };
     };
   };

--- a/src/loading_bar_middleware.js
+++ b/src/loading_bar_middleware.js
@@ -6,10 +6,8 @@ export default function loadingBarMiddleware(config = {}) {
   const promiseTypeSuffixes = config.promiseTypeSuffixes || defaultTypeSuffixes
 
   return ({ dispatch }) => next => action => {
-    next(action)
-
     if (action.type === undefined) {
-      return
+      return false
     }
 
     const [PENDING, FULFILLED, REJECTED] = promiseTypeSuffixes
@@ -24,5 +22,7 @@ export default function loadingBarMiddleware(config = {}) {
                !!action.type.match(isRejected)) {
       dispatch(hideLoading())
     }
+
+    return next(action)
   }
 }

--- a/src/loading_bar_middleware.js
+++ b/src/loading_bar_middleware.js
@@ -14,14 +14,14 @@ export default function loadingBarMiddleware(config = {}) {
 
     const [PENDING, FULFILLED, REJECTED] = promiseTypeSuffixes
 
-    const isPending = `_${PENDING}`
-    const isFulfilled = `_${FULFILLED}`
-    const isRejected = `_${REJECTED}`
+    const isPending = new RegExp(`${PENDING}$`, 'g')
+    const isFulfilled = new RegExp(`${FULFILLED}$`, 'g')
+    const isRejected = new RegExp(`${REJECTED}$`, 'g')
 
-    if (action.type.indexOf(isPending) !== -1) {
+    if (!!action.type.match(isPending)) {
       dispatch(showLoading())
-    } else if (action.type.indexOf(isFulfilled) !== -1 ||
-               action.type.indexOf(isRejected) !== -1) {
+    } else if (!!action.type.match(isFulfilled) ||
+               !!action.type.match(isRejected)) {
       dispatch(hideLoading())
     }
   }


### PR DESCRIPTION
Always `return` `next(action)`

[_source_](http://redux.js.org/docs/advanced/Middleware.html)