### PR TITLE
Return the next action at the end of the middleware, as expected by redux

### DIFF
--- a/build/loading_bar_middleware.js
+++ b/build/loading_bar_middleware.js
@@ -21,6 +21,8 @@ function loadingBarMiddleware() {
     var dispatch = _ref.dispatch;
     return function (next) {
       return function (action) {
+        var nextAction = next(action);
+
         if (action.type === undefined) {
           return false;
         }
@@ -42,7 +44,7 @@ function loadingBarMiddleware() {
           dispatch((0, _loading_bar_ducks.hideLoading)());
         }
 
-        return next(action);
+        return nextAction;
       };
     };
   };

--- a/src/loading_bar_middleware.js
+++ b/src/loading_bar_middleware.js
@@ -6,6 +6,8 @@ export default function loadingBarMiddleware(config = {}) {
   const promiseTypeSuffixes = config.promiseTypeSuffixes || defaultTypeSuffixes
 
   return ({ dispatch }) => next => action => {
+    const nextAction = next(action)
+
     if (action.type === undefined) {
       return false
     }
@@ -23,6 +25,6 @@ export default function loadingBarMiddleware(config = {}) {
       dispatch(hideLoading())
     }
 
-    return next(action)
+    return nextAction
   }
 }


### PR DESCRIPTION
Redux is expecting middlewares to return the next action, if not some weird behavior could happen (it did in my case)

[Source](http://redux.js.org/docs/advanced/Middleware.html)